### PR TITLE
fix: 新規スレッド投稿でエラーが発生する問題

### DIFF
--- a/backend/src/utils/DatabaseManager.py
+++ b/backend/src/utils/DatabaseManager.py
@@ -25,6 +25,8 @@ class DatabaseManager:
             self.db.commit()
             return result
         except mysql.connector.Error as e:
-            error_msg = f"データベースエラー: {str(e)}"
-            raise HTTPException(status_code=500, detail=error_msg)
+            error_msg = f"データベースエラー: errno={e.errno}, msg={e.msg}"
+            print(error_msg)
+            # データベースエラーが発生した場合は、例外を再度投げる
+            raise e
 


### PR DESCRIPTION
原因はスレッドの言語が2文字以内の制限だったが、language=originalで保存しようとしていたため。
DBエラーの出力方法も変更